### PR TITLE
Queues not working because of notation mismatch

### DIFF
--- a/fs.lua
+++ b/fs.lua
@@ -27,8 +27,8 @@ end
 
 function fs.check(key)
 	local limiter = fs.limiters[key]
-	display(limiter)
-	if limiter == nil then return false end
+	-- display(limiter)
+	if limiter == nil then return true end -- no limiter has been set
 
 	local tDelta = getEpoch() - limiter.start
 	if tDelta > limiter.delay then

--- a/qm.lua
+++ b/qm.lua
@@ -135,8 +135,8 @@ qm.Queue = {
                     end
                 end
 
-                if will_action and fs:check('queue') then
-                    fs:on('queue', 0.02)
+                if will_action and fs.check('queue') then
+                    fs.on('queue', 0.02)
                     local code = action.code
                     if type( code ) == "table" then
                         for _,each_code in pairs( code ) do


### PR DESCRIPTION
fa functions defined as fs.check, fs.on etc, so they need to be called that way, as fs:check('queue') is the same as calling fs.check(fs, 'queue') and the code isn't written for that.

Also should return true if there is no limiter set, rather than false.

These changes cause the balqueue to start working again.